### PR TITLE
Added a basic animated content example

### DIFF
--- a/app/src/main/java/com/lmorda/shopper/invite/InviteAFriend.kt
+++ b/app/src/main/java/com/lmorda/shopper/invite/InviteAFriend.kt
@@ -1,11 +1,13 @@
 package com.lmorda.shopper.invite
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -19,6 +21,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.lmorda.shopper.R
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 @Preview
 @Composable
@@ -251,27 +255,41 @@ private fun ShopperHero() {
     )
 }
 
+@OptIn(ExperimentalAnimationApi::class)
 @Composable
 private fun CopyLink(copyLinkClickListener: () -> Unit) {
+    var count by remember { mutableStateOf(0) }
+    val coroutineScope = rememberCoroutineScope()
     Image(
         painter = painterResource(id = R.drawable.ic_link),
         contentDescription = stringResource(R.string.invite_copy_link_ada),
         modifier = Modifier
             .clickable(
                 enabled = true,
-                onClick = copyLinkClickListener
+                onClick = {
+                    copyLinkClickListener()
+                    count++
+                    coroutineScope.launch {
+                        delay(2000)
+                        count = 0
+                    }
+                }
             )
             .fillMaxWidth(),
         alignment = Alignment.Center
     )
     Spacer(modifier = Modifier.padding(4.dp))
-    Text(
-        text = stringResource(R.string.invite_copy_link_icon_text),
-        modifier = Modifier
-            .fillMaxWidth(),
-        textAlign = TextAlign.Center,
-        fontSize = 10.sp
-    )
+    AnimatedContent(targetState = count) { targetCount ->
+        Text(
+            text = if (targetCount == 0)
+                stringResource(R.string.invite_copy_link_icon_text)
+            else stringResource(R.string.invite_link_copied_icon_text),
+            modifier = Modifier
+                .fillMaxWidth(),
+            textAlign = TextAlign.Center,
+            fontSize = 10.sp
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="invite_share_icon_text">SHARE</string>
     <string name="invite_copy_link_ada">Copy Link</string>
     <string name="invite_copy_link_icon_text">COPY LINK</string>
+    <string name="invite_link_copied_icon_text">LINK COPIED</string>
     <string name="invite_message_ada">Message</string>
     <string name="invite_message_icon_text">MESSAGE</string>
     <string name="invite_share_order_ada">Share this order</string>


### PR DESCRIPTION
Added a basic animated text example.  When the share icon is clicked, the text will change to "LINK COPIED" for two seconds and then change back to the default text.  Pretty cool!  Would definitely work better if the whole column was clickable though instead of the icon, TODO for sure.